### PR TITLE
Remove redundant packages

### DIFF
--- a/1.0.0-alpha9/Dockerfile
+++ b/1.0.0-alpha9/Dockerfile
@@ -5,18 +5,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 # Dependencies
-RUN echo "deb http://packages.dotdeb.org wheezy all" >> /etc/apt/sources.list
-RUN echo "deb-src http://packages.dotdeb.org wheezy all" >> /etc/apt/sources.list
-RUN curl http://www.dotdeb.org/dotdeb.gpg | apt-key add -
 RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y zlib1g zlib1g-dev php5-common git mercurial subversion
-RUN apt-get install -y php5-curl php5-gd php5-json php5-mcrypt php5-mysql php5-pgsql php5-readline php5-sqlite sqlite3 mysql-client php5-mysql mcrypt php-pear
-
-# Enable any modules
-RUN php5enmod curl json mysql mysqli pdo_mysql pdo_sqlite readline gd mcrypt pdo sqlite3
-RUN pecl install zip
-RUN echo "extension=zip.so" > /usr/local/etc/php/conf.d/extension-zip.ini
+RUN apt-get install -y zlib1g-dev git mercurial subversion
+RUN docker-php-ext-install zip
 
 # Set memory limit
 RUN echo "memory_limit=1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
@@ -37,4 +28,4 @@ WORKDIR /app
 
 # Set up the command arguments
 CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["composer", "--ansi", "--ignore-platform-reqs"]

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -5,18 +5,9 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 # Dependencies
-RUN echo "deb http://packages.dotdeb.org wheezy all" >> /etc/apt/sources.list
-RUN echo "deb-src http://packages.dotdeb.org wheezy all" >> /etc/apt/sources.list
-RUN curl http://www.dotdeb.org/dotdeb.gpg | apt-key add -
 RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y zlib1g zlib1g-dev php5-common git mercurial subversion
-RUN apt-get install -y php5-curl php5-gd php5-json php5-mcrypt php5-mysql php5-pgsql php5-readline php5-sqlite sqlite3 mysql-client php5-mysql mcrypt php-pear
-
-# Enable any modules
-RUN php5enmod curl json mysql mysqli pdo_mysql pdo_sqlite readline gd mcrypt pdo sqlite3
-RUN pecl install zip
-RUN echo "extension=zip.so" > /usr/local/etc/php/conf.d/extension-zip.ini
+RUN apt-get install -y zlib1g-dev git mercurial subversion
+RUN docker-php-ext-install zip
 
 # Set memory limit
 RUN echo "memory_limit=1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
@@ -37,4 +28,4 @@ WORKDIR /app
 
 # Set up the command arguments
 CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["composer", "--ansi", "--ignore-platform-reqs"]


### PR DESCRIPTION
This PR may be somewhat too big. Please, write back if you think it should be split.

Remove extra packages (sqlite, mysql, postgres, readline, mcrypt, pear, curl, gd). `--ignore-platform-reqs` is added to allow installing packages with platform requirements. 

PHP in the `php:5.6-cli` image is already compiled with json, readline and curl, so these are
removed.

`docker-php-ext-install` script from the PHP image is used to install zip extension.

Also remove wheezy repositories and use original jessie repos from the PHP image

I didn't touch the alpha8 version since it doesn't support `--ignore-platform-reqs` flag and won't be able to install a lot of packages without extra packages.
