### PR TITLE
Clear apt cache after installing dependencies

### DIFF
--- a/1.0.0-alpha9/Dockerfile
+++ b/1.0.0-alpha9/Dockerfile
@@ -2,11 +2,8 @@
 FROM php:5.6-cli
 MAINTAINER Rob Loach <robloach@gmail.com>
 
-ENV DEBIAN_FRONTEND noninteractive
-
 # Dependencies
-RUN apt-get update
-RUN apt-get install -y zlib1g-dev git mercurial subversion
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y zlib1g-dev git mercurial subversion --no-install-recommends && rm -r /var/lib/apt/lists/*
 RUN docker-php-ext-install zip
 
 # Set memory limit

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -2,11 +2,8 @@
 FROM php:5.6-cli
 MAINTAINER Rob Loach <robloach@gmail.com>
 
-ENV DEBIAN_FRONTEND noninteractive
-
 # Dependencies
-RUN apt-get update
-RUN apt-get install -y zlib1g-dev git mercurial subversion
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y zlib1g-dev git mercurial subversion --no-install-recommends && rm -r /var/lib/apt/lists/*
 RUN docker-php-ext-install zip
 
 # Set memory limit


### PR DESCRIPTION
This reduces the image size a little (~24Mb)
Also do not set global DEBIAN_FRONTEND env var as it's considered harmful